### PR TITLE
Make script text pure black

### DIFF
--- a/Fountain/ScriptCSS.css
+++ b/Fountain/ScriptCSS.css
@@ -30,7 +30,7 @@ html {
 }
 body {
 	background-color: #fff;
-	color: #3e3e3e;
+	color: #000000;
 	font: 12px/1.0em 'Courier Prime', serif;
 	padding: 0;
 	margin: 0;


### PR DESCRIPTION
Make script text pure black so that color printers don't try to composite grey out of CMY inks.